### PR TITLE
feat/context: implement advanced context handling

### DIFF
--- a/cfg/context.h
+++ b/cfg/context.h
@@ -59,15 +59,16 @@ public:
         // HandleTODO
 
         // CtxTODO is empty:
-        const auto& related_types = term2nterms.get(symbol);
+        const auto& [related_types, fix_limits] = term2nterms.get(symbol);
         tuple_each_or_return(related_types, [&](std::size_t i, const auto& elem){
             using max_t = std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>;
             const auto& [rule, fix] = elem;
 
             // Get the prefix and postfix positions
             const auto [pre, post] = fix; // fix only contains info for the nterms
-            // TODO get size of prefix and postfix
-            // Max pre/postfix -> ok
+            const auto [max_pre, min_post] = fix_limits; // Get max prefix and min postfix in this rule
+            // Max pre/postfix -> ok, we successfully resolved the rule
+            // If there are no more matches even though we haven't reached the end of the fix, we apply context
 
             // Get index of rule
             constexpr std::size_t rule_id = get_ctx_index<0, std::decay_t<decltype(rule)>>();

--- a/cfg/context.h
+++ b/cfg/context.h
@@ -302,12 +302,11 @@ public:
                 postfix_todo.remove(match_id);
             }
         }
-        if (postfix.fix == stack_size - 1)
+        /*if (postfix.fix == stack_size - 1)
         {
             // We exit ctx now!
-            // TODO we should decrease it from reduce() and assert() on error
-            context[postfix.rule_id]--;
-        }
+            // context[postfix.rule_id]--;
+        }*/
         return prefix_todo.size() + postfix_todo.size() == 0;
     }
 
@@ -333,6 +332,7 @@ public:
     /**
      * @brief Update the context for the reduced symbol. This function should be called on each successful reduce operation
      * @param match Chosen match candidate
+     * @param stack_size Size of the stack before the reduction
      */
     template<class TSymbol>
     constexpr bool apply_reduce(const TSymbol& match, std::size_t stack_size)

--- a/cfg/context.h
+++ b/cfg/context.h
@@ -1,0 +1,137 @@
+//
+// Created by Flynn on 11.05.2025.
+//
+
+#ifndef CONTEXT_H
+#define CONTEXT_H
+
+#include "cfg/base.h"
+#include "cfg/helpers.h"
+#include "cfg/hashtable.h"
+
+
+
+template<class TRules>
+class CtxTODO
+{
+public:
+    std::array<std::size_t, std::tuple_size_v<TRules>> todo;
+    std::size_t n;
+
+    constexpr CtxTODO() : n(0) {}
+};
+
+
+template<class TMatches, class RulesPosPairs, class TRules, class FullRRTree>
+class ContextManager
+{
+public:
+    std::array<std::size_t, std::tuple_size_v<TRules>> context;
+    std::array<std::vector<std::size_t>, std::tuple_size_v<TRules>> ctx_pos; // Positions of context start at each ctx level
+    CtxTODO<TRules> prefix;
+    CtxTODO<TRules> postfix;
+
+    TMatches matches;
+    RulesPosPairs pos;
+    TRules rules;
+    FullRRTree rr_all;
+    std::size_t last_ctx_pos;
+
+    constexpr ContextManager(const TMatches& m, const RulesPosPairs& p, const TRules& r, const FullRRTree& rr_all) : matches(m), pos(p), rules(r), rr_all(rr_all) {}
+
+    /**
+     * @brief Reset the context of the array. Should be performed at the start of parsing
+     */
+    void reset_ctx()
+    {
+        context.fill(0);
+        for (const auto& vec : ctx_pos)
+            vec.assign(1, std::numeric_limits<std::size_t>::max()); // Set ctx pos to null at first ctx level
+        last_ctx_pos = std::numeric_limits<std::size_t>::max();
+    }
+
+    template<class TSymbol, class TermsTypes, class NTermsMap>
+    bool next(const TSymbol& symbol, std::size_t stack_size, const TermsTypes& term2nterms, const NTermsMap& nterms_map, auto descend)
+    {
+        // HandleTODO
+
+        // CtxTODO is empty:
+        const auto& related_types = term2nterms.get(symbol);
+        tuple_morph_each(related_types, [&](std::size_t i, const auto& elem){
+            using max_t = std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>;
+            const auto& [rule, fix] = elem;
+
+            // Get the prefix and postfix positions
+            const auto [pre, post] = fix;
+            // Get index of rule
+            constexpr std::size_t rule_id = get_ctx_index<0, std::decay_t<decltype(rule)>>();
+            // Get ctx for current rule
+            const std::size_t ctx = context[rule_id];
+
+            // Check if current rule can be in context
+
+            // Try to reduce symbol
+            auto perform_check_at_pos = [&](const std::size_t symbol_pos){
+                // Out of bounds check: the rule cannot fit in current stack
+                if (symbol_pos >= stack_size)
+                    return false; // Continue
+
+                std::size_t stack_i = stack_size - 1 - symbol_pos;
+                std::size_t parsed = descend(stack_i, std::get<1>(nterms_map.get(rule)->terms));
+
+                if (parsed >= symbol_pos) // We can theoretically reduce everything up to this symbol OR there is no match at all
+                {
+                    //context[ctx_pos]++; // Successful match
+                    // last_ctx_pos = ctx_pos;
+                    return true;
+                }
+                return false;
+            };
+
+
+            // Is in prefix
+            if constexpr (!std::is_same_v<std::decay_t<decltype(pre)>, max_t>)
+            {
+                // Check if context exists at current ctx level
+                if (ctx_pos[rule_id][ctx] == max_t())
+                {
+                    // Currently not in ctx guessing mode
+                    // Descend
+                    if (perform_check_at_pos(pre))
+                    {
+                        // Found match
+                    }
+                } else {
+                    // Symbol already matched, we only need to check for recursive ctx
+                    // Also need to handle CtxTODO
+                }
+            }
+
+            // Is in postfix
+            if constexpr (!std::is_same_v<std::decay_t<decltype(post)>, max_t>)
+            {
+                // No context exists at current ctx level
+                if (ctx_pos[rule_id][ctx] == max_t())
+                {
+                    // Not in prefix -> cannot obtain starting pos
+                    if constexpr (!std::is_same_v<std::decay_t<decltype(pre)>, max_t>)
+                        return false; // Not found
+
+                    // Use pre as a starting pos
+                    if (perform_check_at_pos(pre))
+                    {
+                        // Found match
+                    }
+                } else {
+                    // Context exists, use it as a starting pos
+                    // Be careful with ctx level start
+
+                }
+            }
+        });
+    }
+};
+
+
+
+#endif //CONTEXT_H

--- a/cfg/context.h
+++ b/cfg/context.h
@@ -78,7 +78,7 @@ public:
 };
 
 
-template<class TMatches, class RulesPosPairs, class TRules, class FullRRTree>
+template<class TMatches, class NTermsPosPairs, class TermsPosPairs, class TRules, class TTerms, class FullRRTree>
 class ContextManager
 {
 public:
@@ -91,12 +91,14 @@ public:
     CtxMeta postfix; // ditto
 
     TMatches matches;
-    RulesPosPairs pos;
-    TRules rules;
+    NTermsPosPairs pos_nterm;
+    TermsPosPairs pos_term;
+    TRules rules; // all rules
+    TTerms t_terms; // all terms
     FullRRTree rr_all;
     std::size_t last_ctx_pos;
 
-    constexpr ContextManager(const TMatches& m, const RulesPosPairs& p, const TRules& r, const FullRRTree& rr_all) : matches(m), pos(p), rules(r), rr_all(rr_all) {}
+    constexpr ContextManager(const TMatches& m, const NTermsPosPairs& p_nterm, const TermsPosPairs& p_term, const TRules& r, const TTerms& all_terms, const FullRRTree& rr_all) : matches(m), pos_nterm(p_nterm), pos_term(p_term), rules(r), t_terms(all_terms), rr_all(rr_all) {}
 
     /**
      * @brief Reset the context of the array. Should be performed at the start of parsing
@@ -113,13 +115,15 @@ public:
         postfix.reset();
     }
 
+    /**
+     * @brief Consume the next token and perform context analysis. Returns false on ambiguity
+     */
     template<class TSymbol, class TermsTypes, class NTermsMap>
     bool next(const TSymbol& symbol, std::size_t stack_size, const TermsTypes& term2nterms, const NTermsMap& nterms_map, auto descend)
     {
-        // HandleTODO
 
-        // CtxTODO is empty:
-        const auto& [related_types, fix_limits] = term2nterms.get(symbol);
+        const auto& [related_types, fix_limits] = get_pos(symbol); /* fetch the value from *PosPairs */;
+
         tuple_each_or_return(related_types, [&](std::size_t i, const auto& elem){
             using max_t = std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>;
             const auto& [rule, fix] = elem;
@@ -235,6 +239,7 @@ public:
             if constexpr (!std::is_same_v<std::decay_t<decltype(post)>, max_t>)
             {
                 // we can also perform additional end-of-stack check (does the prefix+postfix fit?)
+                // also we should check that the prefix rule matches (link prefixes and postfixes together)
 
                 if (prefix.empty() || postfix.empty())
                 {
@@ -308,7 +313,52 @@ public:
         }
         return prefix_todo.size() + postfix_todo.size() == 0;
     }
+
+    template<class TSymbol>
+    constexpr auto& get_pos(const TSymbol& symbol) const
+    {
+        if constexpr (is_nterm<std::decay_t<TSymbol>>)
+            return do_get_nterm_pos<0>(symbol);
+        else
+            return do_get_term_pos<0>(symbol);
+    }
+
+protected:
+    template<std::size_t depth, class TSymbol>
+    constexpr auto do_get_nterm_pos(const TSymbol& symbol) const
+    {
+        static_assert(depth < std::tuple_size_v<TMatches>, "NTerm type not found");
+        // Get the corresponding NTermsPosPairs element
+        if constexpr (std::is_same_v<std::decay_t<TSymbol>, std::tuple_element_t<depth, TRules>>)
+        {
+            return std::get<depth>(pos_nterm);
+        } else {
+            return do_get<depth + 1>(symbol);
+        }
+    }
+
+    template<std::size_t depth, class TSymbol>
+    constexpr auto do_get_term_pos(const TSymbol& symbol) const
+    {
+        static_assert(depth < std::tuple_size_v<TMatches>, "Term type not found");
+        // Get the corresponding NTermsPosPairs element
+        if constexpr (std::is_same_v<std::decay_t<TSymbol>, std::tuple_element_t<depth, TTerms>>)
+        {
+            return std::get<depth>(pos_term);
+        } else {
+            return do_get<depth + 1>(symbol);
+        }
+    }
 };
+
+
+template<bool do_prettyprint, bool do_context_check, class RRTree, class NTermsMap, class TTermsTypeMap, class THeuristicsPre>
+constexpr auto make_ctx_manager(const RRTree& tree, const NTermsMap& nterms2defs, const TTermsTypeMap& terms_map, const THeuristicsPre& h_pre)
+{
+    const auto pairs_nt = cfg_helpers::ctx_get_nterm_match<0>(tree.defs, tree.tree, nterms2defs);
+    const auto pairs_t = cfg_helpers::ctx_get_term_match<0>(terms_map.terms, terms_map.nterms, nterms2defs);
+    return ContextManager<decltype(tree.defs), decltype(pairs_nt), decltype(pairs_t), decltype(h_pre.unique_rr), decltype(terms_map.terms), decltype(h_pre.full_rr), do_prettyprint>(tree.defs, pairs_nt, pairs_t, h_pre.unique_rr, terms_map.terms, h_pre.full_rr);
+}
 
 
 

--- a/cfg/context.h
+++ b/cfg/context.h
@@ -14,11 +14,67 @@
 template<class TRules>
 class CtxTODO
 {
-public:
+protected:
     std::array<std::size_t, std::tuple_size_v<TRules>> todo;
-    std::size_t n;
+    std::size_t n; // size of _todo
+    std::vector<std::size_t> cached_idx; // last added rule index
 
-    constexpr CtxTODO() : n(0) {}
+public:
+    constexpr CtxTODO() : n(0), cached_idx(std::numeric_limits<std::size_t>::max()) {}
+
+    [[nodiscard]] std::size_t size() const { return n; }
+
+    void reset()
+    {
+        n = 0;
+        cached_idx.clear();
+        todo.fill(std::numeric_limits<std::size_t>::max());
+    }
+
+    const std::size_t& operator[](const std::size_t i) { return todo[i]; }
+
+    void remove(const std::size_t rule_id)
+    {
+        todo[rule_id] = std::numeric_limits<std::size_t>::max();
+        n--;
+        cached_idx.pop_back();
+    }
+
+    void add(const std::size_t rule_id, const std::size_t pos)
+    {
+        todo[rule_id] = pos;
+        cached_idx.push_back(rule_id);
+        n++;
+    }
+
+    [[nodiscard]] std::size_t last_added() const
+    {
+        return cached_idx.front();
+    }
+};
+
+
+class CtxMeta
+{
+public:
+    std::size_t rule_id;
+    std::size_t fix;
+
+    constexpr CtxMeta() : rule_id(std::numeric_limits<std::size_t>::max()), fix(std::numeric_limits<std::size_t>::max()) {}
+
+    void reset()
+    {
+        rule_id = std::numeric_limits<std::size_t>::max();
+        fix = std::numeric_limits<std::size_t>::max();
+    }
+
+    void set(const std::size_t rule, const std::size_t pos)
+    {
+        rule_id = rule;
+        fix = pos;
+    }
+
+    bool empty() { return rule_id == std::numeric_limits<std::size_t>::max(); }
 };
 
 
@@ -31,8 +87,8 @@ public:
     CtxTODO<TRules> prefix_todo;
     CtxTODO<TRules> postfix_todo;
 
-    CtxTODO<TRules> prefix; // non-ambiguous prefix match (we do not need the whole array)
-    CtxTODO<TRules> postfix; //
+    CtxMeta prefix; // non-ambiguous prefix match (we do not need the whole array)
+    CtxMeta postfix; // ditto
 
     TMatches matches;
     RulesPosPairs pos;
@@ -51,6 +107,10 @@ public:
         for (const auto& vec : ctx_pos)
             vec.assign(1, std::numeric_limits<std::size_t>::max()); // Set ctx pos to null at first ctx level
         last_ctx_pos = std::numeric_limits<std::size_t>::max();
+        prefix_todo.reset();
+        postfix_todo.reset();
+        prefix.reset();
+        postfix.reset();
     }
 
     template<class TSymbol, class TermsTypes, class NTermsMap>
@@ -65,64 +125,108 @@ public:
             const auto& [rule, fix] = elem;
 
             // Get the prefix and postfix positions
-            const auto [pre, post] = fix; // fix only contains info for the nterms
+            const auto [pre, post_dist] = fix; // fix only contains info for the nterms
             const auto [max_pre, min_post] = fix_limits; // Get max prefix and min postfix in this rule
             // Max pre/postfix -> ok, we successfully resolved the rule
+            const auto post = min_post - post_dist; // Convert post from the distance to the end to an id
             // If there are no more matches even though we haven't reached the end of the fix, we apply context
 
             // Get index of rule
             constexpr std::size_t rule_id = get_ctx_index<0, std::decay_t<decltype(rule)>>();
             // Get ctx for current rule
-            const std::size_t ctx = context[rule_id];
+            // const std::size_t ctx = context[rule_id];
 
             // Check if current rule can be in context
 
-            // Try to check if the prefix matches
-            // I guess that we do not need to perform full descend() check
-            auto is_in_prefix = [&](const std::size_t at, const std::size_t len){
-                //std::size_t parsed = descend(at, std::get<1>(nterms_map.get(rule)->terms));
-                // Check if the last symbol is in the correct prefix pos
-                if constexpr (is_nterm<TSymbol>())
-                    return (at == pre); // Something like this
-                else
+            /*
+             * Ctx resolver pseudocode:
+             * limits <- fix_minmax  // pre/postfix limits
+             * new_todo <- {}
+             * each rr <- related_type:
+             *   pre, post <- fix
+             *   // each pre, post:
+             *   at <- stack_pos - _todo[rr]  // `at` is the relative position in pre/post. if _todo[rr] and _fix[rr] are empty, no check is performed OR we check all symbols from the beginning
+             *                                // if _fix[rr] exists, then we only check when we reach the end. right now we better check and add asserts
+             *   if at == pre/post:  // check if the last stack symbol with relative pos `at` is actually on the position pre/post
+             *     if new_todo != null:
+             *       _todo[rr] += at_pre/at_post  // increment _todo, at_pre/post indicates that we're checking prefix or postfix
+             *     else:
+             *       new_todo[rr] += at_pre/at_post
+             *
+             *    if len(new_todo) == 1:  // we need to check this for both prefix and postfix
+             *      ctx++/--
+             *      // at_pre, at_post:
+             *      _fix[rr] ++  // early ctx application check (save info that we have already applied ctx)
+             *    else:
+             *
+             */
+
+            auto check_ctx = [&](){
+                if constexpr (std::tuple_size_v<std::decay_t<FullRRTree>> > 0)
                 {
-                    // Check the lexical range
-
+                    const auto& idx = get_rr_all(rule);
+                    for (const std::size_t pos : idx)  // rules where it cannot be present
+                    {
+                        if (context[pos] > 0) return false;
+                    }
                 }
-
-                /*if (parsed >= len) // We can theoretically reduce everything up to this symbol OR there is no match at all
-                {
-                    //context[ctx_pos]++; // Successful match
-                    // last_ctx_pos = ctx_pos;
-                    return true;
-                }
-                return false;*/
-            };
-
-            auto handle_match_and_todo = [&](const auto& todo){
-
+                return true;
             };
 
 
             // Is in prefix
             if constexpr (!std::is_same_v<std::decay_t<decltype(pre)>, max_t>)
             {
-                // Currently not in ctx guessing mode
-                // Descend
-                if (pre >= stack_size) return false; // cannot fit in current stack
-                const std::size_t at = stack_size - 1 - pre;
-                if (perform_check_at_pos(at, pre))
+                // we can also perform additional end-of-stack check (does the prefix+postfix fit?)
+
+                if (prefix.empty() || postfix.empty())
                 {
-                    // Found match
-
-                    // Check if context exists at current ctx level
-                    if (ctx_pos[rule_id][ctx] == max_t())
+                    // we're currently matching non-ambiguous ctx
+                    // applied prefix or postfix are blocking: no new matches can happen
+                    if (prefix.rule_id == rule_id)
                     {
-                        // Symbol has not been matched yet
+                        // use _fix as the starting pos
+                        if (stack_size - 1 - prefix.fix != pre)
+                        {
+                            // we have already applied the ctx, unexpected behavior
+                            // ASSERT
+                        }
+                        if (stack_size - 1 - prefix.fix == max_pre)
+                        {
+                            // we reached the end
+                            prefix.reset();
+                        }
+                    }
+                }
+                else if (prefix_todo[rule_id] != max_t())
+                {
+                    // use _todo as the starting pos
+                    // TODO add optional (if pre == max_pre -> apply)
+                    if (stack_size - 1 - prefix_todo[rule_id] == pre)
+                    {
+                        // FOUND
+                        // nothing to do - prefix is already in _todo
                     } else {
-                        // Symbol already matched, we need to check for recursive ctx
-                        // Also need to handle CtxTODO
+                        // candidate dropped out
+                        prefix_todo.remove(rule_id);
+                    }
+                } else {
+                    // first match
 
+                    if (pre == 0)
+                    {
+                        if (check_ctx())
+                        {
+                            // rule can exist in current ctx
+                            // nothing else to check
+                            // FOUND
+                            prefix_todo.add(rule_id, stack_size - 1);
+                        }
+                    } else {
+                        // we need different logic for handling cases when prefix != 0
+                        // permissive handler:
+                        if (pre < stack_size)  // sanity check
+                            prefix_todo.add(rule_id, stack_size - 1 - pre);
                     }
                 }
             }
@@ -130,32 +234,79 @@ public:
             // Is in postfix
             if constexpr (!std::is_same_v<std::decay_t<decltype(post)>, max_t>)
             {
-                // No context exists at current ctx level
-                if (ctx_pos[rule_id][ctx] == max_t())
-                {
-                    // Not in prefix -> cannot obtain starting pos
-                    if constexpr (!std::is_same_v<std::decay_t<decltype(pre)>, max_t>)
-                        return false; // Not found
+                // we can also perform additional end-of-stack check (does the prefix+postfix fit?)
 
-                    // Use pre as a starting pos
-                    if (pre >= stack_size) return false; // cannot fit in current stack
-                    const std::size_t stack_i = stack_size - 1 - pre;
-                    if (perform_check_at_pos(stack_i, pre))
+                if (prefix.empty() || postfix.empty())
+                {
+                    // we're currently matching non-ambiguous ctx
+                    // applied prefix or postfix are blocking: no new matches can happen
+                    if (postfix.rule_id == rule_id)
                     {
-                        // Found match
+                        // use _fix as the starting pos
+                        if (postfix.fix + post != stack_size - 1)
+                        {
+                            // we have already applied the ctx, unexpected behavior
+                            // ASSERT
+                        }
+                        if (post_dist == 0)
+                        {
+                            // we reached the end
+                            // FOUND
+                            postfix.reset();
+                        }
+                    }
+                }
+                else if (postfix_todo[rule_id] != max_t())
+                {
+                    // use _todo as the starting pos
+                    if (postfix_todo[rule_id] + post == stack_size - 1)
+                    {
+                        // FOUND
+                        // nothing to do - prefix is already in _todo
+                    } else {
+                        // candidate dropped out
+                        postfix_todo.remove(rule_id);
                     }
                 } else {
-                    // Context exists, use it as a starting pos
-                    // Be careful with ctx level start
-                    const std::size_t at = ctx_pos[rule_id][ctx];
-                    if (at >= stack_size) return false;
-                    if (perform_check_at_pos(at, stack_size - at)) // (stack_size - at) is the number of symbols up to the stack end
+                    // first match
+
+                    if (post == 0)
                     {
-                        // Found match
+                        // FOUND
+                        postfix_todo.add(rule_id, stack_size - 1);
+                    } else {
+                        // we need different logic for handling cases when prefix != 0
+                        // permissive handler:
+                        if (post < stack_size)  // sanity check (we need to account for prefix overlap)
+                            postfix_todo.add(rule_id, stack_size - 1 - post);
                     }
                 }
             }
         });
+
+        // _todo solver
+        if (prefix_todo.size() + postfix_todo.size() == 1)
+        {
+            // No ambiguities!
+            // find non-empty rule
+            if (prefix_todo.size() == 1)
+            {
+                std::size_t match_id = prefix_todo.last_added();
+                context[match_id]++;
+                prefix.set(match_id, prefix_todo[match_id]);
+                prefix_todo.remove(match_id);
+            } else {
+                std::size_t match_id = postfix_todo.last_added();
+                postfix.set(match_id, postfix_todo[match_id]);
+                postfix_todo.remove(match_id);
+            }
+        }
+        if (postfix.fix == stack_size - 1)
+        {
+            // We exit ctx now!
+            context[postfix.rule_id]--;
+        }
+        return prefix_todo.size() + postfix_todo.size() == 0;
     }
 };
 

--- a/cfg/hashtable.h
+++ b/cfg/hashtable.h
@@ -47,6 +47,11 @@ public:
         Val v = value;
         storage.insert({key, ValuesVariant(v)});
     }
+
+    bool contains(const Key& key) const
+    {
+        return storage.contains(key);
+    }
 };
 
 

--- a/cfg/preprocess.h
+++ b/cfg/preprocess.h
@@ -1015,4 +1015,22 @@ protected:
 class NoReducibilityChecker {};
 
 
+// Heuristics preprocessing helpers
+enum class HeuristicFeatures : std::uint64_t
+{
+    ContextManagement = 0x1, // Build the FullRRTree
+};
+
+
+template<class UniqueRelatedRules, class FullRRTree>
+class HeuristicPreprocessor
+{
+public:
+    UniqueRelatedRules unique_rr;
+    FullRRTree full_rr;
+
+    constexpr HeuristicPreprocessor(const UniqueRelatedRules& u_rr, const FullRRTree& full_rr_tree) : unique_rr(u_rr), full_rr(full_rr_tree) {}
+};
+
+
 #endif //SUPERCFG_PREPROCESS_H

--- a/cfg/preprocess_factories.h
+++ b/cfg/preprocess_factories.h
@@ -357,16 +357,7 @@ namespace cfg_helpers
             const auto& rule_nterm = std::get<i>(r_rules);
             const auto& rule_def = std::get<1>(nterms2defs.get(rule_nterm)->terms);
 
-            auto null_to_max = []<class TRes>(const TRes& res){
-                if constexpr (std::is_same_v<std::decay_t<TRes>, std::tuple<>>)
-                    return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
-                else return res;
-            };
-
-            const auto prefix = null_to_max(rc1_rule_get_fix<true, 0, 0>(def, rule_def));
-            const auto postfix = null_to_max(rc1_rule_get_fix<false, 0, std::tuple_size_v<std::decay_t<decltype(rule_def.terms)>> - 1>(def, rule_def));
-
-            return std::make_tuple(std::make_pair(rule_nterm, std::make_pair(prefix, postfix)));
+            return rc1_get_elem_pos_in_rule<0, 0>(def, rule_def, rule_nterm);
         });
 
         if constexpr (depth + 1 < std::tuple_size_v<TDefsTuple>)
@@ -740,14 +731,14 @@ constexpr auto make_reducibility_checker1(const RRTree& tree, const NTermsMap& n
 {
     const auto all_related_rules = tuple_unique(tuple_flatten_layer(tree.tree)); // Get a tuple of all unique related rules
     const auto pairs = cfg_helpers::rc1_get_match<0>(tree.defs, tree.tree, nterms2defs);
-    if constexpr (do_context_check)
+    /*if constexpr (do_context_check)
     {
         if constexpr (do_prettyprint)
             std::cout << "  RC(1) FULL REVERSE TREE" << std::endl;
         const auto rr_all = cfg_helpers::rc1_get_full_rrtree<do_prettyprint, 0>(tree.defs, tree, all_related_rules);
         return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), decltype(rr_all), do_prettyprint>(tree.defs, pairs, all_related_rules, rr_all);
     }
-    else return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), std::tuple<>, do_prettyprint>(tree.defs, pairs, all_related_rules, std::tuple<>());
+    else*/ return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), std::tuple<>, do_prettyprint>(tree.defs, pairs, all_related_rules, std::tuple<>());
 }
 
 

--- a/cfg/preprocess_factories.h
+++ b/cfg/preprocess_factories.h
@@ -385,7 +385,7 @@ namespace cfg_helpers
     template<class TSymbol, class RRulesTuple, class NTermsMap>
     constexpr auto ctx_get_match_step(const TSymbol& def, const RRulesTuple& r_rules, const NTermsMap& nterms2defs)
     {
-        const auto fix_minmax = std::pair<std::size_t, std::size_t>();
+        const auto fix_minmax = std::pair<std::size_t, std::size_t>(0, std::numeric_limits<std::size_t>::max());
 
         const auto res = concat_each<std::tuple_size_v<std::decay_t<decltype(r_rules)>>, true>([&]<std::size_t i>(){
             const auto& rule_nterm = std::get<i>(r_rules);

--- a/cfg/preprocess_factories.h
+++ b/cfg/preprocess_factories.h
@@ -274,7 +274,12 @@ namespace cfg_helpers
                 return std::integral_constant<std::size_t, pos>{}; // We do not need to wrap it into a tuple
             else
                 return std::tuple<>();
-        } else return std::tuple<>();
+        } else {
+            // We need to handle cases when target is a range
+            if constexpr (terms_intersect_v<std::decay_t<TDef>, std::decay_t<TSymbol>>)
+                return std::integral_constant<std::size_t, pos>{};
+            else return std::tuple<>(); // No intersection or target is an nterm
+        }
     }
 
     /**
@@ -286,6 +291,7 @@ namespace cfg_helpers
     template<std::size_t pos, std::size_t i, class TDef, class TSymbol, class TRuleDef>
     constexpr auto rc1_get_elem_pos_in_rule(const TDef& target, const TSymbol& symbol, const TRuleDef& rule)
     {
+        // TODO Delete this dead code
         if constexpr (is_operator<TSymbol>())
         {
             if constexpr (get_operator<TSymbol>() == OpType::Concat)
@@ -336,7 +342,7 @@ namespace cfg_helpers
     }
 
     /**
-     * @brief Iterate over each symbol, get the related rules and find the starting position in prefix and postfix
+     * @brief Iterate over each nterm, get the related rules and find the starting position in prefix and postfix
      * @param defs RRTree defs tuple
      * @param rules RRTree rules tuple
      * @param nterms2defs NTerms to definitions mapping
@@ -368,6 +374,43 @@ namespace cfg_helpers
         else
             return std::make_tuple(res);
     }
+
+
+    /**
+     * @brief Same as rc1_get_match, but finds Terms and TermsRange in rules
+     * @param terms TermsTypeMap terms
+     * @param nterms TermsTypeMap nterms (rules)
+     * @param nterms2defs NTerms to definitions mapping
+     */
+    template<std::size_t depth, class TTermsTuple, class TDefsTuple, class NTermsMap>
+    constexpr auto ctx_get_term_match(const TTermsTuple& terms, const TDefsTuple& nterms, const NTermsMap& nterms2defs)
+    {
+        const auto& def = std::get<depth>(terms);
+        const auto& r_rules = std::get<depth>(nterms);
+
+        const auto res = concat_each<std::tuple_size_v<std::decay_t<decltype(r_rules)>>, true>([&]<std::size_t i>(){
+            const auto& rule_nterm = std::get<i>(r_rules);
+            const auto& rule_def = std::get<1>(nterms2defs.get(rule_nterm)->terms);
+
+            auto null_to_max = []<class TRes>(const TRes& res){
+                if constexpr (std::is_same_v<std::decay_t<TRes>, std::tuple<>>)
+                    return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
+                else return res;
+            };
+
+            // Warning: due to TermsRange symbol pos is still kind of ambiguous!
+            const auto prefix = null_to_max(rc1_rule_get_fix<true, 0, 0>(def, rule_def));
+            const auto postfix = null_to_max(rc1_rule_get_fix<false, 0, std::tuple_size_v<std::decay_t<decltype(rule_def.terms)>> - 1>(def, rule_def));
+
+            return std::make_tuple(std::make_pair(rule_nterm, std::make_pair(prefix, postfix)));
+        });
+
+        if constexpr (depth + 1 < std::tuple_size_v<TDefsTuple>)
+            return std::tuple_cat(std::make_tuple(res), ctx_get_term_match<depth+1>(terms, nterms, nterms2defs));
+        else
+            return std::make_tuple(res);
+    }
+
 
     template<class TSymbol, class TVisitedTuple, class TRuleTree>
     constexpr auto rc1_full_rrtree_recurse(const TSymbol& symbol, const TVisitedTuple& visited, const TRuleTree& rules)

--- a/cfg/preprocess_factories.h
+++ b/cfg/preprocess_factories.h
@@ -224,6 +224,60 @@ namespace cfg_helpers
     // reducibility checker
 
     /**
+     * @brief Get position of a symbol in the prefix or postfix of a given rule. (Pre/Post)fix is a sequence of symbols which is always present at a particular position. If a symbol always occurs more than once, only the first match is resolved
+     * @tparam dir_up Up (true) - prefix, down (false) - postfix
+     * @param target Symbol to check
+     * @param symbol Symbol to descend into
+     */
+    template<bool dir_up, std::size_t pos, std::size_t i, class TDef, class TSymbol>
+    constexpr auto rc1_rule_get_fix(const TDef& target, const TSymbol& symbol)
+    {
+        // Can we move to the next symbol?
+        constexpr bool next = (dir_up ? i < std::tuple_size_v<std::decay_t<decltype(symbol.terms)>> : i > 0);
+        constexpr std::size_t i_next = (dir_up ? i + 1 : i - 1);
+
+        if constexpr (is_operator<TSymbol>())
+        {
+            if constexpr (get_operator<TSymbol>() == OpType::Concat)
+            {
+                // At each step increase the pos and return if we find one encounter
+                // Descend into symbol
+                const auto res = rc1_rule_get_fix<pos, 0>(target, std::get<i>(symbol.terms));
+                if constexpr (next && std::is_same_v<std::decay_t<decltype(res)>, std::tuple<>>)
+                {
+                    // Target not found, check the next term in symbol
+                    return rc1_rule_get_fix<pos+1, i_next>(target, symbol);
+                } else return res;
+            }
+            // Only deterministic prefix or postfix is Concat and repeat with M >= 1
+            else if constexpr (get_operator<TSymbol>() == OpType::RepeatExact || get_operator<TSymbol>() == OpType::RepeatRange || get_operator<TSymbol>() == OpType::RepeatGE)
+            {
+                if constexpr (get_range_from<TSymbol>() > 0)
+                    // Get the FIRST entry
+                    return rc1_rule_get_fix<pos, 0>(target, std::get<0>(symbol.terms));
+                else return std::tuple<>();
+            }
+            else if constexpr (get_operator<TSymbol>() == OpType::Group)
+            {
+                // Check only the first symbol
+                if constexpr (std::tuple_size_v<std::decay_t<decltype(symbol.terms)>> == 0)
+                    return std::tuple<>();
+                else
+                    return rc1_rule_get_fix<pos, 0>(target, std::get<0>(symbol.terms));
+            }
+            // Other symbols are not deterministic
+            else return std::tuple<>();
+        }
+        else if constexpr (is_nterm<TSymbol>())
+        {
+            if constexpr (std::is_same_v<std::decay_t<TDef>, std::decay_t<TSymbol>>)
+                return std::integral_constant<std::size_t, pos>{}; // We do not need to wrap it into a tuple
+            else
+                return std::tuple<>();
+        } else return std::tuple<>();
+    }
+
+    /**
      * @brief Get the first element encounter position
      * @param target Symbol to check
      * @param symbol Symbol to descend into
@@ -282,7 +336,7 @@ namespace cfg_helpers
     }
 
     /**
-     * @brief Iterate over each symbol, get the related rules and find the starting position
+     * @brief Iterate over each symbol, get the related rules and find the starting position in prefix and postfix
      * @param defs RRTree defs tuple
      * @param rules RRTree rules tuple
      * @param nterms2defs NTerms to definitions mapping
@@ -296,13 +350,110 @@ namespace cfg_helpers
         const auto res = concat_each<std::tuple_size_v<std::decay_t<decltype(r_rules)>>, true>([&]<std::size_t i>(){
             const auto& rule_nterm = std::get<i>(r_rules);
             const auto& rule_def = std::get<1>(nterms2defs.get(rule_nterm)->terms);
-            return rc1_get_elem_pos_in_rule<0, 0>(def, rule_def, rule_nterm);
+
+            auto null_to_max = []<class TRes>(const TRes& res){
+                if constexpr (std::is_same_v<std::decay_t<TRes>, std::tuple<>>)
+                    return std::integral_constant<std::size_t, std::numeric_limits<std::size_t>::max()>{};
+                else return res;
+            };
+
+            const auto prefix = null_to_max(rc1_rule_get_fix<true, 0, 0>(def, rule_def));
+            const auto postfix = null_to_max(rc1_rule_get_fix<false, 0, std::tuple_size_v<std::decay_t<decltype(rule_def.terms)>> - 1>(def, rule_def));
+
+            return std::make_tuple(std::make_pair(rule_nterm, std::make_pair(prefix, postfix)));
         });
 
         if constexpr (depth + 1 < std::tuple_size_v<TDefsTuple>)
             return std::tuple_cat(std::make_tuple(res), rc1_get_match<depth+1>(defs, rules, nterms2defs));
         else
             return std::make_tuple(res);
+    }
+
+    template<class TSymbol, class TVisitedTuple, class TRuleTree>
+    constexpr auto rc1_full_rrtree_recurse(const TSymbol& symbol, const TVisitedTuple& visited, const TRuleTree& rules)
+    {
+        if constexpr (tuple_contains_v<std::decay_t<TSymbol>, std::decay_t<TVisitedTuple>>)
+            return std::tuple<>();
+        else
+        {
+            const auto& related = rules.get(symbol);
+            const auto visited_next = std::tuple_cat(visited, std::make_tuple(symbol));
+            return tuple_morph_each<true>(related, [&](std::size_t i, const auto& elem){ return std::tuple_cat(std::make_tuple(elem), rc1_full_rrtree_recurse(elem, visited_next, rules)); });
+        }
+    }
+
+    template<std::size_t depth, class TSymbol, class SymbolsTuple>
+    [[nodiscard]] constexpr std::size_t rc1_get_ctx_index()
+    {
+        static_assert(depth < std::tuple_size_v<SymbolsTuple>, "No such symbol found");
+        if constexpr (std::is_same_v<std::decay_t<std::tuple_element_t<depth, SymbolsTuple>>, std::decay_t<TSymbol>>)
+            return depth;
+        else
+            return rc1_get_ctx_index<depth+1, TSymbol, SymbolsTuple>();
+    }
+
+    template<std::size_t N, std::array<std::size_t, N> ctx, std::size_t i, std::size_t MAX>
+    constexpr auto ctx_inv()
+    {
+        if constexpr ([&](){
+            for (std::size_t j = 0; j < N; j++)
+            {
+                if (ctx[j] == i)
+                    return false;
+            }
+            return true;
+        }())
+        {
+            if constexpr (i + 1 < MAX)
+                return std::tuple_cat(std::make_tuple(i), ctx_inv<N, ctx, i+1, MAX>());
+            else
+                return std::make_tuple(i);
+        } else {
+            if constexpr (i + 1 < MAX)
+                return ctx_inv<N, ctx, i+1, MAX>();
+            else
+                return std::tuple<>();
+        }
+    }
+
+    /**
+     * @brief Generate a reverse rules tree which contains all possible nterms. The resulting tuple contains N arrays of rule indices, where element is never present
+     */
+    template<bool do_prettyprint, std::size_t depth, class TDefsTuple, class TRuleTree, class TRules>
+    constexpr auto rc1_get_full_rrtree(const TDefsTuple& defs, const TRuleTree& rules, const TRules& all_rules)
+    {
+        const auto& def = std::get<0>(std::get<depth>(defs).terms);
+        // iterate over related rules and recurse until we find a loop
+        const auto related = tuple_unique(rc1_full_rrtree_recurse(def, std::tuple<>(), rules));
+        if constexpr (do_prettyprint)
+        {
+            std::cout << def.type() << " -> ";
+            print_symbols_tuple(related);
+        }
+
+        constexpr std::size_t M = std::tuple_size_v<std::decay_t<decltype(related)>>;
+        // Convert explicit symbols into idx
+        constexpr auto related_idx = h_type_morph<std::array<std::size_t, M>, true>([&]<std::size_t i>(const auto& src){
+            return rc1_get_ctx_index<0, std::decay_t<std::tuple_element_t<i, std::decay_t<decltype(related)>>>, std::decay_t<TRules>>();
+        }, IntegralWrapper<M>{}, related);
+
+        constexpr std::size_t ctx_size_inv = std::tuple_size_v<std::decay_t<TRules>> - M;
+        constexpr auto ctx_inv_tup = ctx_inv<M, related_idx, 0, std::tuple_size_v<std::decay_t<TRules>>>();
+        constexpr auto related_idx_inv = h_type_morph<std::array<std::size_t, ctx_size_inv>, true>([&]<std::size_t i>(const auto& src){ return std::get<i>(ctx_inv_tup); }, IntegralWrapper<ctx_size_inv>{}, ctx_inv_tup);
+
+        if constexpr (do_prettyprint)
+        {
+            std::cout << ", idx : {";
+            for (std::size_t idx : related_idx) std::cout << idx << " ";
+            std::cout << "}, inv : {";
+            for (std::size_t idx : related_idx_inv) std::cout << idx << " ";
+            std::cout << "}" << std::endl;
+        }
+
+        if constexpr (depth + 1 < std::tuple_size_v<TDefsTuple>)
+            return std::tuple_cat(std::make_tuple(related_idx_inv), rc1_get_full_rrtree<do_prettyprint, depth+1>(defs, rules, all_rules));
+        else
+            return std::make_tuple(related_idx_inv);
     }
 
     template<std::size_t i, class TRange, class TSybmol>
@@ -497,12 +648,19 @@ auto terms_type_map_factory(const TypesCache& cache)
 }
 
 
-template<bool do_prettyprint, class RRTree, class NTermsMap>
+template<bool do_prettyprint, bool do_context_check, class RRTree, class NTermsMap>
 constexpr auto make_reducibility_checker1(const RRTree& tree, const NTermsMap& nterms2defs)
 {
     const auto all_related_rules = tuple_unique(tuple_flatten_layer(tree.tree)); // Get a tuple of all unique related rules
     const auto pairs = cfg_helpers::rc1_get_match<0>(tree.defs, tree.tree, nterms2defs);
-    return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), do_prettyprint>(tree.defs, pairs, all_related_rules);
+    if constexpr (do_context_check)
+    {
+        if constexpr (do_prettyprint)
+            std::cout << "  RC(1) FULL REVERSE TREE" << std::endl;
+        const auto rr_all = cfg_helpers::rc1_get_full_rrtree<do_prettyprint, 0>(tree.defs, tree, all_related_rules);
+        return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), decltype(rr_all), do_prettyprint>(tree.defs, pairs, all_related_rules, rr_all);
+    }
+    else return ReducibilityChecker1<decltype(tree.defs), decltype(pairs), decltype(all_related_rules), std::tuple<>, do_prettyprint>(tree.defs, pairs, all_related_rules, std::tuple<>());
 }
 
 

--- a/cfg/preprocess_factories.h
+++ b/cfg/preprocess_factories.h
@@ -751,6 +751,21 @@ constexpr auto make_reducibility_checker1(const RRTree& tree, const NTermsMap& n
 }
 
 
+template<bool do_prettyprint, HeuristicFeatures features, class RRTree, class NTermsMap>
+constexpr auto make_heuristic_preprocessor(const RRTree& tree)
+{
+    const auto all_related_rules = tuple_unique(tuple_flatten_layer(tree.tree));
+    if constexpr((std::uint64_t)features & (std::uint64_t)HeuristicFeatures::ContextManagement)
+    {
+        const auto rr_all = cfg_helpers::rc1_get_full_rrtree<do_prettyprint, 0>(tree.defs, tree, all_related_rules);
+        return HeuristicPreprocessor(all_related_rules, rr_all);
+    } else {
+        return HeuristicPreprocessor(all_related_rules, std::tuple<>());
+    }
+}
+
+
+
 /**
  * @brief Lexer configuration
  */

--- a/examples/json.cpp
+++ b/examples/json.cpp
@@ -75,7 +75,8 @@ int main()
     constexpr auto conf = mk_sr_parser_conf<
         SRConfEnum::PrettyPrint,  // Enable pretty printing for debugging
         SRConfEnum::Lookahead,     // Enable lookahead(1)
-        SRConfEnum::ReducibilityChecker>(); // Enable RC(1)
+        SRConfEnum::ReducibilityChecker, // Enable RC(1)
+        SRConfEnum::RC1CheckContext>(); // Enable RC(1) advanced context check
 
 
     // Initialize the tokenizer


### PR DESCRIPTION
Right now the parser has the limited ability to handle reduce-reduce conflicts and ambiguities. In order to improve the handling of these cases, the parser needs to analyze the current context - the nesting level of each rule at a given state of the stack.

This advancement allows the reduce mechanism to dynamically take decisions based on which rules can be nested inside others. Context analysis works by parsing prefix and postfix of each rule. Prefix and postfix is the sequence of terminals or nonterminals which is always present in the current rule:

In JSON, for an object `obj := { (member (, member)*)? }` the prefix would be `[ '[' ]` and the postfix would be `[ ']' ]`, while for a quoted string `str := " <char> "` the prefix and postfix would be equal to `[ '"' ]`.

If there occurs a collision between prefixes and postfixes, the reduce operation is not performed until the ambiguity is resolved. The exact behavior should be configurable for enabling or disabling more precise context checks.

As this mechanism heavily relies on the presence of deterministic prefixes and postfixes, the current version of this algorithm cannot properly resolve context for rules without deterministic prefix and postfix. This may be solved in the future versions.

Feature progress:

- [X] Generate constant mapping between each symbol and its position in prefix and postfix
- [x] Implement separate context manager class which isolates context logic from `reduce()`
- [x] Implement PrefixTODO and PostfixTODO stacks for resolving prefix and postfix ambiguities/collisions.
- [x] Update `reduce()` logic to enable context checks